### PR TITLE
Report selectors when matches fails

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,19 +1,21 @@
----
-js:
-  beautify_on_save: true
-  brace_style: collapse-preserve-inline
-  break_chained_methods: false
-  end_with_newline: true
-  indent_char: " "
-  indent_size: 2
-  indent_level: 0
-  indent_with_tabs: false
-  jslint_happy: true
-  keep_array_indentation: false
-  keep_function_indentation: false
-  max_preserve_newlines: 2
-  preserve_newlines: true
-  space_after_anon_function: true
-  space_before_conditional: true
-  space_in_paren: false
-  unescape_strings: false
+{
+  "js": {
+    "beautify_on_save": true,
+    "brace_style": "collapse,preserve-inline",
+    "break_chained_methods": false,
+    "end_with_newline": true,
+    "indent_char": " ",
+    "indent_size": 2,
+    "indent_level": 0,
+    "indent_with_tabs": false,
+    "jslint_happy": true,
+    "keep_array_indentation": false,
+    "keep_function_indentation": false,
+    "max_preserve_newlines": 2,
+    "preserve_newlines": true,
+    "space_after_anon_function": true,
+    "space_before_conditional": true,
+    "space_in_paren": false,
+    "unescape_strings": false
+  }
+}

--- a/src/util.js
+++ b/src/util.js
@@ -12,7 +12,12 @@ export function executeFunctionOrArrayOfFunctions(fn, element, evt) {
 
 export function matches(selector, element) {
   if (typeof selector === "function") return selector(element);
-  return element.matches(selector);
+  try {
+    return element.matches(selector);
+  } catch (err) {
+    console.warn(`Executing selector "${selector}" resulted in an error`);
+    throw err;
+  }
 }
 
 export function* previousSiblings(el) {


### PR DESCRIPTION
Made this change because I found two selector errors when debugging an issue is Safari. It was very hard to isolate where the errors were. I added this code to help me so I thought it may be useful to others.

I included the update to .jsbeautifyrc in this commit to make it conform with the specification that it be a JSON file.